### PR TITLE
Add support for navigating to metrics services by named path

### DIFF
--- a/grafana/config/grafana.ini
+++ b/grafana/config/grafana.ini
@@ -1,5 +1,0 @@
-[paths]
-provisioning = /etc/grafana/provisioning
-
-[server]
-enable_gzip = true

--- a/grafana/config/grafana.local.ini
+++ b/grafana/config/grafana.local.ini
@@ -1,0 +1,9 @@
+instance_name = localhost
+
+[paths]
+provisioning = /etc/grafana/provisioning
+
+[server]
+enable_gzip = true
+protocol = http
+root_url = https://localhost/metrics/

--- a/grafana/config/grafana.prod.ini
+++ b/grafana/config/grafana.prod.ini
@@ -1,4 +1,4 @@
-instance_name = localhost
+instance_name = stko-kwg
 
 [paths]
 provisioning = /etc/grafana/provisioning

--- a/grafana/config/grafana.prod.ini
+++ b/grafana/config/grafana.prod.ini
@@ -1,0 +1,9 @@
+instance_name = localhost
+
+[paths]
+provisioning = /etc/grafana/provisioning
+
+[server]
+enable_gzip = true
+protocol = http
+root_url = https://stko-kwg.geog.ucsb.edu/metrics/

--- a/grafana/config/grafana.stage.ini
+++ b/grafana/config/grafana.stage.ini
@@ -1,4 +1,4 @@
-instance_name = localhost
+instance_name = staging.knowwheregraph
 
 [paths]
 provisioning = /etc/grafana/provisioning

--- a/grafana/config/grafana.stage.ini
+++ b/grafana/config/grafana.stage.ini
@@ -1,0 +1,9 @@
+instance_name = localhost
+
+[paths]
+provisioning = /etc/grafana/provisioning
+
+[server]
+enable_gzip = true
+protocol = http
+root_url = https://stage.knowwheregraph.org/metrics/

--- a/grafana/docker-compose.local.yaml
+++ b/grafana/docker-compose.local.yaml
@@ -1,0 +1,21 @@
+services:
+  grafana:
+      image: grafana/grafana:10.4.2
+      container_name: grafana
+      volumes:
+        - ./grafana/persistent_config:/var/lib/grafana # Persists grafana configurations
+        - ./grafana/provisioning:/etc/grafana/provisioning # Source for the data source and dashboard definitions
+        - ./grafana/config/grafana.local.ini:/etc/grafana/grafana.ini # Grafana custom config
+        - ./grafana/config/dashboards:/etc/grafana/dashboards # Dashboard JSON definitions
+      environment:
+        - GF_USERS_ALLOW_SIGN_UP=false
+        - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
+        - GF_SECURITY_ADMIN_USER=admin
+        - GF_SECURITY_ADMIN_PASSWORD=password
+      env_file:
+        - 'variables.env'
+      restart: unless-stopped
+      ports:
+        - 3000:3000
+      networks:
+        - kwg_network

--- a/grafana/docker-compose.prod.yaml
+++ b/grafana/docker-compose.prod.yaml
@@ -1,0 +1,21 @@
+services:
+  grafana:
+      image: grafana/grafana:10.4.2
+      container_name: grafana
+      volumes:
+        - ./grafana/persistent_config:/var/lib/grafana # Persists grafana configurations
+        - ./grafana/provisioning:/etc/grafana/provisioning # Source for the data source and dashboard definitions
+        - ./grafana/config/grafana.prod.ini:/etc/grafana/grafana.ini # Grafana custom config
+        - ./grafana/config/dashboards:/etc/grafana/dashboards # Dashboard JSON definitions
+      environment:
+        - GF_USERS_ALLOW_SIGN_UP=false
+        - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
+        - GF_SECURITY_ADMIN_USER=admin
+        - GF_SECURITY_ADMIN_PASSWORD=password
+      env_file:
+        - 'variables.env'
+      restart: unless-stopped
+      ports:
+        - 3000:3000
+      networks:
+        - kwg_network

--- a/grafana/docker-compose.stage.yaml
+++ b/grafana/docker-compose.stage.yaml
@@ -5,7 +5,7 @@ services:
       volumes:
         - ./grafana/persistent_config:/var/lib/grafana # Persists grafana configurations
         - ./grafana/provisioning:/etc/grafana/provisioning # Source for the data source and dashboard definitions
-        - ./grafana/config/grafana.ini:/etc/grafana/grafana.ini # Grafana custom config
+        - ./grafana/config/grafana.stage.ini:/etc/grafana/grafana.ini # Grafana custom config
         - ./grafana/config/dashboards:/etc/grafana/dashboards # Dashboard JSON definitions
       environment:
         - GF_USERS_ALLOW_SIGN_UP=false

--- a/makefile
+++ b/makefile
@@ -1,9 +1,9 @@
 THIS_FILE := $(lastword $(MAKEFILE_LIST))
 .PHONY: help start stop restart
 
-BUILD_FILES_PROD := docker-compose.yaml -f nginx/docker-compose.prod.yaml -f graphdb/docker-compose.prod.yaml -f elasticsearch/docker-compose.yaml -f prometheus/docker-compose.yaml -f kwg-api/docker-compose.prod.yaml 
-BUILD_FILES_LOCAL := docker-compose.yaml -f nginx/docker-compose.local.yaml -f graphdb/docker-compose.local.yaml -f elasticsearch/docker-compose.yaml -f prometheus/docker-compose.yaml -f kwg-api/docker-compose.local.yaml -f grafana/docker-compose.yaml
-BUILD_FILES_STAGE := docker-compose.yaml -f nginx/docker-compose.stage.yaml -f graphdb/docker-compose.stage.yaml -f elasticsearch/docker-compose.yaml -f prometheus/docker-compose.yaml -f kwg-api/docker-compose.local.yaml -f grafana/docker-compose.yaml
+BUILD_FILES_PROD := docker-compose.yaml -f nginx/docker-compose.prod.yaml -f graphdb/docker-compose.prod.yaml -f elasticsearch/docker-compose.yaml -f prometheus/docker-compose.yaml -f kwg-api/docker-compose.prod.yaml -f grafana/docker-compose.prod.yaml
+BUILD_FILES_LOCAL := docker-compose.yaml -f nginx/docker-compose.local.yaml -f graphdb/docker-compose.local.yaml -f elasticsearch/docker-compose.yaml -f prometheus/docker-compose.yaml -f kwg-api/docker-compose.local.yaml -f grafana/docker-compose.local.yaml
+BUILD_FILES_STAGE := docker-compose.yaml -f nginx/docker-compose.stage.yaml -f graphdb/docker-compose.stage.yaml -f elasticsearch/docker-compose.yaml -f prometheus/docker-compose.yaml -f kwg-api/docker-compose.local.yaml -f grafana/docker-compose.stage.yaml 
 
 help:	## Show this help.
 	@sed -ne '/@sed/!s/## //p' $(MAKEFILE_LIST)

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -48,6 +48,27 @@ server {
         proxy_set_header X-Forwarded-Prefix /;
     }
 
+    # Forward Grafana traffic to /metrics
+    location /metrics/ {
+        proxy_pass http://grafana:3000/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    # Forward prometheus traffic to /prometheus
+    location /prometheus/ {
+        proxy_pass http://prometheus:9090/;
+        rewrite /prometheus/(.*) /$1  break;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+
     # Static Node Browser
     location /browse {
         alias /usr/share/nginx/html/node-browser/node-browser/dist/node-browser/;

--- a/prometheus/docker-compose.yaml
+++ b/prometheus/docker-compose.yaml
@@ -8,6 +8,10 @@ services:
       - 9090:9090
     networks:
       - kwg_network
+    command:
+      - --web.route-prefix=/
+      - --config.file=/etc/prometheus/prometheus.yml
+
 
   node-exporter:
     image: prom/node-exporter


### PR DESCRIPTION
Fixes #24 

Couple networking changes to move off of port based services. We need a different grafana ini file for each environment, which lead to a new docker-compose for each environment (to mount the different file)