### PR TITLE
Allow docker's IP range

### DIFF
--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -26,6 +26,9 @@ server {
    location /stub_status {
         stub_status on;
         allow 127.0.0.1;
+        allow 172.0.0.0/12;
+        allow 172.16.0.0/15;
+        allow 172.18.0.0/24;
         deny all;
     }
 


### PR DESCRIPTION
This PR allows services in the docker subnet to access the nginx statistics (used for metrics). Fixes #28 