### PR TITLE
Cap elasticsearch heap to 3gb

### DIFF
--- a/elasticsearch/docker-compose.yaml
+++ b/elasticsearch/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
     environment:
       - xpack.security.enabled=true
       - discovery.type=single-node
+      - ES_JAVA_OPTS=-Xms3g -Xmx3g
     ports:
       - "9200:9200"
     networks:


### PR DESCRIPTION
Fix for #27 

This PR adds a 3gb cap to ES's heap. We can tune this as needed