### PR TITLE
Bump ES version, add log aggregation, bump GraphDB version, add ontology sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,13 @@ LetsEncrypt can't be used for local HTTPS . More information can be found on Let
 
 ### Updating Environmental Variables
 
-Environmental variables are kept in the `variables.env`. These variables are used across deployments and within NGINX; they can be injected into any container.
+Some evironmental variables are kept in the `variables.env`. These variables are used across deployments and within NGINX; they can be injected into any container.
 
 `GRAPH_DB_HOSTNAME`: The name for the graphdb service
 
 `ES_HOSTNAME`: The name for the elasticsearch service
+
+`ELASTIC_PASSWORD`: The password for elasticsearch
 
 `API_HOSTNAME`: The name for the KWG API service
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The following steps aren't automated and will need to be done *before* bringing 
 6. Modify `variables.env` to specify the name of the GraphDB repository the `sparql/` endpoint should query
 7. Modify `variables.env` with the Elasticsearch password
 8. Modify `variables.env` with the server name - without `http` or `www` (localhost/staging.knowwheregraph.org/stko-kwg.geog.ucsb.edu)
+9. On a new server, install the loki docker plugin with `docker plugin install grafana/loki-docker-driver:main--alias loki  --grant-all-permissions`
 
 ### Production Environment
 

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -10,8 +10,12 @@ ElasticSearch can be independently deployed with
 
 ## User Account
 
-ElasticSearch is configured to be run under an authenticated account, `elastic` with the password set in the docker-compose file.
+ElasticSearch is configured to be run under an authenticated account, `elastic` with the password set in the root `variables.env` file.
 
 ## Logs
 
 ElasticSearch logs can be checked with `docker logs <container_id>`
+
+## Creating the GraphDB Index
+
+The SPARQL query to create the elasticsearch index is provided in `connector.sparql`. Enter the correct password and run the query through GraphDB's interface to create the index.

--- a/elasticsearch/connector.sparql
+++ b/elasticsearch/connector.sparql
@@ -1,0 +1,189 @@
+PREFIX :<http://www.ontotext.com/connectors/elasticsearch#>
+PREFIX kwgr: <http://stko-kwg.geog.ucsb.edu/lod/resource/>
+PREFIX gnis: <http://gnis-ld.org/lod/gnis/ontology/>
+PREFIX kwg-ont: <http://stko-kwg.geog.ucsb.edu/lod/ontology/>
+
+PREFIX inst:<http://www.ontotext.com/connectors/elasticsearch/instance#>
+INSERT DATA {
+	inst:labels :createConnector '''
+{
+  "fields": [
+    {
+      "fieldName": "labels",
+      "propertyChain": [
+        "http://www.w3.org/2000/01/rdf-schema#label"
+      ],
+      "indexed": true,
+      "stored": true,
+      "analyzed": true,
+      "multivalued": true,
+      "ignoreInvalidValues": false,
+      "fielddata": false,
+      "array": false,
+      "objectFields": []
+    },
+    {
+      "fieldName": "comment",
+      "propertyChain": [
+        "http://www.w3.org/2000/01/rdf-schema#comment"
+      ],
+      "indexed": true,
+      "stored": true,
+      "analyzed": false,
+      "multivalued": true,
+      "ignoreInvalidValues": false,
+      "fielddata": true,
+      "array": false,
+      "objectFields": []
+    },
+    {
+      "fieldName": "isFeatureOfInterestOf",
+      "propertyChain": [
+        "http://www.w3.org/ns/sosa/isFeatureOfInterestOf",
+        "http://www.w3.org/2000/01/rdf-schema#label"
+      ],
+      "indexed": true,
+      "stored": true,
+      "analyzed": false,
+      "multivalued": true,
+      "ignoreInvalidValues": false,
+      "fielddata": true,
+      "array": false,
+      "objectFields": []
+    },
+    {
+      "fieldName": "locatedIn",
+      "propertyChain": [
+        "http://stko-kwg.geog.ucsb.edu/lod/ontology/locatedIn",
+        "http://www.w3.org/2000/01/rdf-schema#label"
+      ],
+      "indexed": true,
+      "stored": true,
+      "analyzed": false,
+      "multivalued": true,
+      "ignoreInvalidValues": false,
+      "fielddata": true,
+      "array": false,
+      "objectFields": []
+    },
+    {
+      "fieldName": "sfWithin",
+      "propertyChain": [
+        "http://www.opengis.net/ont/geosparql#sfWithin",
+        "http://www.w3.org/2000/01/rdf-schema#label"
+      ],
+      "indexed": true,
+      "stored": true,
+      "analyzed": false,
+      "multivalued": true,
+      "ignoreInvalidValues": false,
+      "fielddata": true,
+      "array": false,
+      "objectFields": []
+    },
+  ],
+  "languages": [],
+  "types": [
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/DroughtZone",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/AdministrativeRegion_0",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/AdministrativeRegion_1",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/AdministrativeRegion_2",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/AdministrativeRegion_3",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/AdministrativeRegion_4",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/AdministrativeRegion_5",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/SmokePlumeSnapshot",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/Earthquake",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/ZipCodeArea",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/FederalJudicialDistrict",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/ClimateDivision",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NationalWeatherZone",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NIFC_Wildfire",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/MTBS_Fire",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_ThunderstormWindEvent",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_HailEvent",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/FEMA_Disaster",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/MTBS_Wildfire",
+    "http://gnis-ld.org/lod/gnis/ontology/Stream",
+    "http://gnis-ld.org/lod/gnis/ontology/Church",
+    "http://gnis-ld.org/lod/gnis/ontology/School",
+    "http://gnis-ld.org/lod/gnis/ontology/PopulatedPlace",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/Pharmacy",
+    "http://gnis-ld.org/lod/gnis/ontology/Building",
+    "http://gnis-ld.org/lod/gnis/ontology/Locale",
+    "http://gnis-ld.org/lod/gnis/ontology/Cemetery",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/Program",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_HighWindEvent",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_FlashFloodEvent",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_TornadoEvent",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_WinterStormEvent",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_WinterWeatherEvent",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_DroughtEvent",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_FloodEvent",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_HeavySnowEvent",
+    "http://gnis-ld.org/lod/gnis/ontology/Reservoir",
+    "http://gnis-ld.org/lod/gnis/ontology/Lake",
+    "http://gnis-ld.org/lod/gnis/ontology/Park",
+    "http://gnis-ld.org/lod/gnis/ontology/Summit",
+    "http://gnis-ld.org/lod/gnis/ontology/Valley",
+    "http://gnis-ld.org/lod/gnis/ontology/CivilGovernment",
+    "http://gnis-ld.org/lod/gnis/ontology/PostOffice",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NIFC_PrescribedFire",
+    "http://gnis-ld.org/lod/gnis/ontology/Dam",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_MarineThunderstormWindEvent",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/BlueSkyWildfire",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/BPHC_Site",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/MTBS_PrescribedFire",
+    "http://gnis-ld.org/lod/gnis/ontology/Well",
+    "http://gnis-ld.org/lod/gnis/ontology/Spring",
+    "http://gnis-ld.org/lod/gnis/ontology/Mine",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_StrongWindEvent",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/AirQualitySite",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_HeavyRainEvent",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_HeatEvent",
+    "http://gnis-ld.org/lod/gnis/ontology/Airport",
+    "http://gnis-ld.org/lod/gnis/ontology/Canal",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_ExcessiveHeatEvent",
+    "http://gnis-ld.org/lod/gnis/ontology/Island",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_ExtremeCold/WindChillEvent",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/PublicHealthObservationCollection",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_Cold/WindChillEvent",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_Hurricane",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_BlizzardEvent",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_LightningEvent",
+    "http://gnis-ld.org/lod/gnis/ontology/Tower",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_DenseFogEvent",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_Frost/FreezeEvent",
+    "http://gnis-ld.org/lod/gnis/ontology/Cape",
+    "http://gnis-ld.org/lod/gnis/ontology/Hospital",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/MTBS_FireObservation",
+    "http://gnis-ld.org/lod/gnis/ontology/Ridge",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/ProtectiveMeasures",
+    "http://gnis-ld.org/lod/gnis/ontology/Census",
+    "http://gnis-ld.org/lod/gnis/ontology/Bay",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_IceStormEvent",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/IndividualAssistance",
+    "http://gnis-ld.org/lod/gnis/ontology/Trail",
+    "http://gnis-ld.org/lod/gnis/ontology/Flat",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/DebrisRemoval",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_TropicalStorm",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_FunnelCloudEvent",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/NOAA_WildfireEvent",
+    "http://gnis-ld.org/lod/gnis/ontology/Gap",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/PublicAssistance",
+    "http://stko-kwg.geog.ucsb.edu/lod/ontology/WaterControlFacilities"
+  ],
+  "readonly": false,
+  "detectFields": false,
+  "importGraph": false,
+  "skipInitialIndexing": false,
+  "elasticsearchClusterSniff": true,
+  "elasticsearchNode": "elasticsearch:9200",
+  "elasticsearchBasicAuthUser": "elastic",
+  "elasticsearchBasicAuthPassword": "PASSWORD_HERE",
+
+  "manageIndex": true,
+  "manageMapping": true,
+  "bulkUpdateBatchSize": 5000
+}
+''' .
+}

--- a/elasticsearch/docker-compose.yaml
+++ b/elasticsearch/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: elasticsearch:8.11.1
+    image: elasticsearch:8.15.1
     container_name: elasticsearch
     environment:
       - xpack.security.enabled=true

--- a/elasticsearch/docker-compose.yaml
+++ b/elasticsearch/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: elasticsearch:8.0.0
+    image: elasticsearch:8.9.2
     container_name: elasticsearch
     environment:
       - xpack.security.enabled=true

--- a/elasticsearch/docker-compose.yaml
+++ b/elasticsearch/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: elasticsearch:8.9.2
+    image: elasticsearch:8.11.1
     container_name: elasticsearch
     environment:
       - xpack.security.enabled=true

--- a/fetch-repositories.sh
+++ b/fetch-repositories.sh
@@ -2,3 +2,4 @@ git clone https://github.com/KnowWhereGraph/node-browser.git nginx/sites/node-br
 git clone https://github.com/KnowWhereGraph/kw-panels.git nginx/sites/kw-panels
 git clone https://github.com/KnowWhereGraph/kwg-faceted-search.git nginx/sites/kwg-faceted-search
 git clone https://github.com/KnowWhereGraph/kwg-api.git kwg-api/
+git clone https://github.com/KnowWhereGraph/kwg-ontologies.git nginx/sites/onto/

--- a/grafana/provisioning/datasources/all.yml
+++ b/grafana/provisioning/datasources/all.yml
@@ -3,7 +3,13 @@ apiVersion: 1
 datasources:
   - name: prometheus
     type: prometheus
-    url: http://prometheus:9090 
+    url: http://prometheus:9090
     isDefault: true
+    access: proxy
+    editable: true
+  - name: Loki
+    type: loki
+    url: http://loki:3100
+    isDefault: false
     access: proxy
     editable: true

--- a/graphdb/docker-compose.local.preload.yaml
+++ b/graphdb/docker-compose.local.preload.yaml
@@ -2,7 +2,7 @@
 services:
   graphdb:
     container_name: graphdb
-    image: ontotext/graphdb:10.7.0
+    image: ontotext/graphdb:10.7.3
     environment: 
       GDB_JAVA_OPTS: >-
         -Dgraphdb.home=/opt/graphdb/home

--- a/graphdb/docker-compose.local.yaml
+++ b/graphdb/docker-compose.local.yaml
@@ -2,7 +2,7 @@
 services:
   graphdb:
     container_name: graphdb
-    image: ontotext/graphdb:10.7.0
+    image: ontotext/graphdb:10.7.3
     restart: unless-stopped
     environment: 
       GDB_JAVA_OPTS: >-

--- a/graphdb/docker-compose.prod.preload.yaml
+++ b/graphdb/docker-compose.prod.preload.yaml
@@ -2,7 +2,7 @@
 services:
   graphdb:
     container_name: graphdb
-    image: ontotext/graphdb:10.7.0
+    image: ontotext/graphdb:10.7.3
     environment: 
       GDB_JAVA_OPTS: >-
         -Xms128g -Xmx256g
@@ -20,6 +20,7 @@ services:
         -Dhealth.max.query.time.seconds=600
         -Dgraphdb.append.request.id.headers=true
         -Dreuse.vars.in.subselects=true
+        -Ddefault.min.distinct.threshold=1G
     env_file:
       - 'variables.env'
     ports: 

--- a/graphdb/docker-compose.prod.yaml
+++ b/graphdb/docker-compose.prod.yaml
@@ -2,7 +2,7 @@
 services:
   graphdb:
     container_name: graphdb
-    image: ontotext/graphdb:10.7.0
+    image: ontotext/graphdb:10.7.3
     restart: unless-stopped
     environment: 
       GDB_JAVA_OPTS: >-
@@ -21,6 +21,7 @@ services:
         -Dhealth.max.query.time.seconds=600
         -Dgraphdb.append.request.id.headers=true
         -Dreuse.vars.in.subselects=true
+        -Ddefault.min.distinct.threshold=1G
     env_file:
       - 'variables.env'
     ports: 

--- a/graphdb/docker-compose.stage.preload.yaml
+++ b/graphdb/docker-compose.stage.preload.yaml
@@ -2,7 +2,7 @@
 services:
   graphdb:
     container_name: graphdb
-    image: ontotext/graphdb:10.7.0
+    image: ontotext/graphdb:10.7.3
     environment: 
       GDB_JAVA_OPTS: >-
         -Dgraphdb.home=/opt/graphdb/home
@@ -14,6 +14,7 @@ services:
         -Dgraphdb.append.request.id.headers=true
         -Dreuse.vars.in.subselects=true
         -Dgraphdb.page.cache.size=2g
+        -Ddefault.min.distinct.threshold=1G
     volumes:
       - ./graphdb/graphdb-data/home:/opt/graphdb/home/
       - ./graphdb/graphdb-data/work/data/V7-SantaBarbara/aboxes-trig:/opt/graphdb/home/import-data

--- a/graphdb/docker-compose.stage.yaml
+++ b/graphdb/docker-compose.stage.yaml
@@ -1,10 +1,9 @@
 # Modified from https://github.com/Ontotext-AD/graphdb-docker/tree/master
-# Dgraphdb.page.cache.size=50g
 
 services:
   graphdb:
     container_name: graphdb
-    image: ontotext/graphdb:10.7.0
+    image: ontotext/graphdb:10.7.3
     restart: unless-stopped
     environment: 
       GDB_JAVA_OPTS: >-
@@ -19,6 +18,8 @@ services:
         -Dhealth.max.query.time.seconds=600
         -Dgraphdb.append.request.id.headers=true
         -Dreuse.vars.in.subselects=true
+        -Ddefault.min.distinct.threshold=1G
+        -Dgraphdb.page.cache.size=2g
     volumes:
       - ./graphdb/graphdb-data/home:/opt/graphdb/home/
       - ./graphdb/graphdb-data/work/data/V7-SantaBarbara/aboxes-trig:/opt/graphdb/home/import-data

--- a/loki/docker-compose.yaml
+++ b/loki/docker-compose.yaml
@@ -1,0 +1,23 @@
+version: "3"
+
+services:
+  loki:
+    image: grafana/loki:2.9.2
+    container_name: loki
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/loki-config.yaml
+    volumes:
+      - ./loki/:/etc/loki/
+    networks:
+      - kwg_network
+
+  promtail:
+    image: grafana/promtail:2.9.2
+    container_name: pomtail
+    volumes:
+      - ./loki/:/etc/loki
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: -config.file=/etc/loki/pomtail-config.yaml
+    networks:
+      - kwg_network

--- a/loki/loki-config.yaml
+++ b/loki/loki-config.yaml
@@ -1,0 +1,56 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  http_server_read_timeout: 600s
+  http_server_write_timeout: 600s
+  
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+querier:
+  max_concurrent: 2048
+query_scheduler:
+  max_outstanding_requests_per_tenant: 2048
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+compactor:
+  working_directory: /loki/retention
+  shared_store: filesystem
+  compaction_interval: 10m
+  retention_enabled: true
+  retention_delete_delay: 2h
+  retention_delete_worker_count: 150
+
+limits_config:
+  retention_period: 180d
+  max_query_series: 100000

--- a/loki/pomtail-config.yaml
+++ b/loki/pomtail-config.yaml
@@ -1,0 +1,24 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: flog_scrape
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+
+    relabel_configs:
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/(.*)'
+        target_label: 'container'
+      - source_labels: ['__meta_docker_container_log_stream']
+        target_label: 'logstream'
+      - source_labels: ['__meta_docker_container_label_logging_jobname']
+        target_label: 'job'

--- a/makefile
+++ b/makefile
@@ -9,20 +9,20 @@ help:	## Show this help.
 	@sed -ne '/@sed/!s/## //p' $(MAKEFILE_LIST)
 
 start-prod:	## Brings the stack online, for https://stko-kwg.geog.ucsb.edu building images if needed
-	docker-compose -f ${BUILD_FILES_PROD} up -d $(c)
+	docker compose -f ${BUILD_FILES_PROD} up -d $(c)
 stop-prod:	## Brings the stack offline
-	docker-compose -f ${BUILD_FILES_PROD} down $(c)
+	docker compose -f ${BUILD_FILES_PROD} down $(c)
 start-local:	## Brings the stack online, for running on a local development machine
-	docker-compose -f ${BUILD_FILES_LOCAL} up -d $(c)
+	docker compose -f ${BUILD_FILES_LOCAL} up -d $(c)
 stop-local:	## Brings the stack offline
-	docker-compose -f ${BUILD_FILES_LOCAL} down $(c)
+	docker compose -f ${BUILD_FILES_LOCAL} down $(c)
 start-stage:	## Brings the stack online for staging.knowwheregraph.org, building images if needed
-	docker-compose -f ${BUILD_FILES_STAGE} up -d $(c)
+	docker compose -f ${BUILD_FILES_STAGE} up -d $(c)
 stop-stage:	## Brings the stack offline for staging.knowwheregraph.org
-	docker-compose -f ${BUILD_FILES_STAGE} down $(c)
+	docker compose -f ${BUILD_FILES_STAGE} down $(c)
 start-local-preload: # Ingests data into GraphDB for the first time. Only launches GraphDB. For local development
-	docker-compose -f docker-compose.yaml -f graphdb/docker-compose.local.preload.yaml up -d $(c)
+	docker compose -f docker-compose.yaml -f graphdb/docker-compose.local.preload.yaml up -d $(c)
 start-stage-preload: # Ingests data into GraphDB for the first time. Only launches GraphDB. For stage deployment
-	docker-compose -f docker-compose.yaml -f graphdb/docker-compose.stage.preload.yaml up -d $(c)
+	docker compose -f docker-compose.yaml -f graphdb/docker-compose.stage.preload.yaml up -d $(c)
 start-prod-preload: # Ingests data into GraphDB for the first time. Only launches GraphDB. For prod deployment
-	docker-compose -f docker-compose.yaml -f graphdb/docker-compose.prod.preload.yaml up -d $(c)
+	docker compose -f docker-compose.yaml -f graphdb/docker-compose.prod.preload.yaml up -d $(c)

--- a/makefile
+++ b/makefile
@@ -1,9 +1,9 @@
 THIS_FILE := $(lastword $(MAKEFILE_LIST))
 .PHONY: help start stop restart
 
-BUILD_FILES_PROD := docker-compose.yaml -f nginx/docker-compose.prod.yaml -f graphdb/docker-compose.prod.yaml -f elasticsearch/docker-compose.yaml -f prometheus/docker-compose.yaml -f kwg-api/docker-compose.prod.yaml -f grafana/docker-compose.prod.yaml
-BUILD_FILES_LOCAL := docker-compose.yaml -f nginx/docker-compose.local.yaml -f graphdb/docker-compose.local.yaml -f elasticsearch/docker-compose.yaml -f prometheus/docker-compose.yaml -f kwg-api/docker-compose.local.yaml -f grafana/docker-compose.local.yaml
-BUILD_FILES_STAGE := docker-compose.yaml -f nginx/docker-compose.stage.yaml -f graphdb/docker-compose.stage.yaml -f elasticsearch/docker-compose.yaml -f prometheus/docker-compose.yaml -f kwg-api/docker-compose.stage.yaml -f grafana/docker-compose.stage.yaml 
+BUILD_FILES_PROD := docker-compose.yaml -f nginx/docker-compose.prod.yaml -f graphdb/docker-compose.prod.yaml -f elasticsearch/docker-compose.yaml -f prometheus/docker-compose.yaml -f kwg-api/docker-compose.prod.yaml -f grafana/docker-compose.prod.yaml -f loki/docker-compose.yaml
+BUILD_FILES_LOCAL := docker-compose.yaml -f nginx/docker-compose.local.yaml -f graphdb/docker-compose.local.yaml -f elasticsearch/docker-compose.yaml -f prometheus/docker-compose.yaml -f kwg-api/docker-compose.local.yaml -f grafana/docker-compose.local.yaml -f loki/docker-compose.yaml
+BUILD_FILES_STAGE := docker-compose.yaml -f nginx/docker-compose.stage.yaml -f graphdb/docker-compose.stage.yaml -f elasticsearch/docker-compose.yaml -f prometheus/docker-compose.yaml -f kwg-api/docker-compose.stage.yaml -f grafana/docker-compose.stage.yaml -f loki/docker-compose.yaml
 
 help:	## Show this help.
 	@sed -ne '/@sed/!s/## //p' $(MAKEFILE_LIST)

--- a/makefile
+++ b/makefile
@@ -1,9 +1,9 @@
 THIS_FILE := $(lastword $(MAKEFILE_LIST))
 .PHONY: help start stop restart
 
-BUILD_FILES_PROD := docker-compose.yaml -f nginx/docker-compose.prod.yaml -f graphdb/docker-compose.prod.yaml -f elasticsearch/docker-compose.yaml -f prometheus/docker-compose.yaml -f kwg-api/docker-compose.prod.yaml -f grafana/docker-compose.prod.yaml -f loki/docker-compose.yaml
-BUILD_FILES_LOCAL := docker-compose.yaml -f nginx/docker-compose.local.yaml -f graphdb/docker-compose.local.yaml -f elasticsearch/docker-compose.yaml -f prometheus/docker-compose.yaml -f kwg-api/docker-compose.local.yaml -f grafana/docker-compose.local.yaml -f loki/docker-compose.yaml
-BUILD_FILES_STAGE := docker-compose.yaml -f nginx/docker-compose.stage.yaml -f graphdb/docker-compose.stage.yaml -f elasticsearch/docker-compose.yaml -f prometheus/docker-compose.yaml -f kwg-api/docker-compose.stage.yaml -f grafana/docker-compose.stage.yaml -f loki/docker-compose.yaml
+BUILD_FILES_PROD := docker-compose.yaml -f nginx/docker-compose.prod.yaml -f nginx/metrics/docker-compose.yaml -f graphdb/docker-compose.prod.yaml -f elasticsearch/docker-compose.yaml -f prometheus/docker-compose.yaml -f kwg-api/docker-compose.prod.yaml -f grafana/docker-compose.prod.yaml -f loki/docker-compose.yaml
+BUILD_FILES_LOCAL := docker-compose.yaml -f nginx/docker-compose.local.yaml -f nginx/metrics/docker-compose.yaml -f graphdb/docker-compose.local.yaml -f elasticsearch/docker-compose.yaml -f prometheus/docker-compose.yaml -f kwg-api/docker-compose.local.yaml -f grafana/docker-compose.local.yaml -f loki/docker-compose.yaml
+BUILD_FILES_STAGE := docker-compose.yaml -f nginx/docker-compose.stage.yaml -f nginx/metrics/docker-compose.yaml -f graphdb/docker-compose.stage.yaml -f elasticsearch/docker-compose.yaml -f prometheus/docker-compose.yaml -f kwg-api/docker-compose.stage.yaml -f grafana/docker-compose.stage.yaml -f loki/docker-compose.yaml
 
 help:	## Show this help.
 	@sed -ne '/@sed/!s/## //p' $(MAKEFILE_LIST)

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -44,3 +44,54 @@ The NGINX logs are found in the container's /var/logs/nginx, which is mounted lo
 ## Metrics
 
 Metrics are exported to prometheus through the nginx/nginx-prometheus-exporter container, which is defined in the `metrics/` folder.
+
+## Adding Ontologies
+
+The ontology URI space competes with the API. Because of this, it's necessary to be precise with the ontology assets: the rdf files, the html, and resources the html references. To add a new ontology site, use the template below, replacing the `nifc-wildfire` information with your own.
+
+```
+    location = /lod/ontology/nifc-wildfire.ttl {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/ontology.ttl;
+    }
+    location = /lod/ontology/nifc-wildfire.nt {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/ontology.nt;
+    }
+    location = /lod/ontology/nifc-wildfire.jsonld {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/ontology.jsonld;
+    }
+    location = /lod/ontology/nifc-wildfire.rdf {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/ontology.rdf;
+    }
+    location = /lod/ontology/nifc-wildfire/ {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/;
+        index index-en.html;
+    }
+    location = /lod/ontology/nifc-wildfire {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/;
+        index index-en.html;
+    }
+    location = /lod/ontology/nifc-wildfire/resources/marked.min.js {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/resources/marked.min.js;
+    }
+    location = /lod/ontology/nifc-wildfire/resources/jquery.js {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/resources/jquery.js;
+    }
+    location = /lod/ontology/nifc-wildfire/resources/owl.css {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/resources/owl.css;
+    }
+    location = /lod/ontology/nifc-wildfire/resources/extra.css {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/resources/extra.css;
+    }
+    location = /lod/ontology/nifc-wildfire/resources/primer.css {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/resources/primer.css;
+    }
+    location = /lod/ontology/nifc-wildfire/resources/rec.css {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/resources/rec.css;
+    }
+    location = /lod/ontology/nifc-wildfire/figures/national-weather-zone-schema-diagram.png {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/figures/national-weather-zone-schema-diagram.png;
+    }
+    location = /lod/ontology/nifc-wildfire/index-en.html {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/index-en.html;
+    }
+```

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -40,3 +40,7 @@ https://javorszky.co.uk/2019/11/06/get-firefox-to-trust-your-self-signed-certifi
 ## Logging
 
 The NGINX logs are found in the container's /var/logs/nginx, which is mounted locally at `./nginx/logs`. For more verbose logging, refer to the NGINX Docker image documentation and modify the deployment script to include any additional flags.
+
+## Metrics
+
+Metrics are exported to prometheus through the nginx/nginx-prometheus-exporter container, which is defined in the `metrics/` folder.

--- a/nginx/docker-compose.local.yaml
+++ b/nginx/docker-compose.local.yaml
@@ -17,18 +17,3 @@ services:
       - kwg-api
     networks:
       - kwg_network
-
-  prometheus-nginx-exporter:
-    image: nginx/nginx-prometheus-exporter:1.1
-    container_name: prometheus-nginx-exporter
-    restart: always
-    ports:
-      - "9113:9113"
-    command:
-      - -nginx.scrape-uri=http://nginx/stub_status
-    depends_on:
-      - nginx
-    expose: 
-      - 9113
-    networks:
-      - kwg_network

--- a/nginx/docker-compose.prod.yaml
+++ b/nginx/docker-compose.prod.yaml
@@ -17,18 +17,3 @@ services:
       - kwg-api
     networks:
       - kwg_network
-
-  prometheus-nginx-exporter:
-    image: nginx/nginx-prometheus-exporter:1.1
-    container_name: prometheus-nginx-exporter
-    restart: always
-    ports:
-      - "9113:9113"
-    command:
-      - -nginx.scrape-uri=http://nginx/stub_status
-    depends_on:
-      - nginx
-    expose: 
-      - 9113
-    networks:
-      - kwg_network

--- a/nginx/docker-compose.stage.yaml
+++ b/nginx/docker-compose.stage.yaml
@@ -18,17 +18,3 @@ services:
     networks:
       - kwg_network
 
-  prometheus-nginx-exporter:
-    image: nginx/nginx-prometheus-exporter:1.1
-    container_name: prometheus-nginx-exporter
-    restart: always
-    ports:
-      - "9113:9113"
-    command:
-      - -nginx.scrape-uri=http://nginx/stub_status
-    depends_on:
-      - nginx
-    expose: 
-      - 9113
-    networks:
-      - kwg_network

--- a/nginx/metrics/docker-compose.yaml
+++ b/nginx/metrics/docker-compose.yaml
@@ -1,0 +1,14 @@
+  prometheus-nginx-exporter:
+    image: nginx/nginx-prometheus-exporter:1.3
+    container_name: prometheus-nginx-exporter
+    restart: always
+    ports:
+      - "9113:9113"
+    command:
+      - -nginx.scrape-uri=http://nginx/stub_status
+    depends_on:
+      - nginx
+    expose: 
+      - 9113
+    networks:
+      - kwg_network

--- a/nginx/metrics/docker-compose.yaml
+++ b/nginx/metrics/docker-compose.yaml
@@ -1,3 +1,4 @@
+services:
   prometheus-nginx-exporter:
     image: nginx/nginx-prometheus-exporter:1.3
     container_name: prometheus-nginx-exporter

--- a/nginx/sites/void/void.ttl
+++ b/nginx/sites/void/void.ttl
@@ -1,1 +1,0 @@
-void file

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -125,10 +125,10 @@ server {
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
     
-        # Set a 5 minute timeout for long running queries
-        proxy_read_timeout 300;
-        proxy_connect_timeout 300;
-        proxy_send_timeout 300;
+        # Set a 10 minute timeout for long running queries
+        proxy_read_timeout 600;
+        proxy_connect_timeout 600;
+        proxy_send_timeout 600;
     }
     
     # VOID Descriptor

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -32,6 +32,533 @@ server {
         deny all;
     }
 
+    #
+    # admin-regions-gadm-documentation
+    #
+    location = /lod/ontology/gadm-administrative-areas.ttl {
+        alias /usr/share/nginx/html/onto/admin-regions-gadm-documentation/ontology.ttl;
+    }
+    location = /lod/ontology/gadm-administrative-areas.nt {
+        alias /usr/share/nginx/html/onto/admin-regions-gadm-documentation/ontology.nt;
+    }
+    location = /lod/ontology/gadm-administrative-areas.jsonld {
+        alias /usr/share/nginx/html/onto/admin-regions-gadm-documentation/ontology.jsonld;
+    }
+    location = /lod/ontology/gadm-administrative-areas.rdf {
+        alias /usr/share/nginx/html/onto/admin-regions-gadm-documentation/ontology.rdf;
+    }
+    location = /lod/ontology/gadm-administrative-areas/ {
+        alias /usr/share/nginx/html/onto/admin-regions-gadm-documentation/;
+        index index-en.html;
+    }
+    location = /lod/ontology/gadm-administrative-areas {
+        alias /usr/share/nginx/html/onto/admin-regions-gadm-documentation/;
+        index index-en.html;
+    }
+    location = /lod/ontology/gadm-administrative-areas/resources/marked.min.js {
+        alias /usr/share/nginx/html/onto/admin-regions-gadm-documentation/resources/marked.min.js;
+    }
+    location = /lod/ontology/gadm-administrative-areas/resources/jquery.js {
+        alias /usr/share/nginx/html/onto/admin-regions-gadm-documentation/resources/jquery.js;
+    }
+    location = /lod/ontology/gadm-administrative-areas/resources/owl.css {
+        alias /usr/share/nginx/html/onto/admin-regions-gadm-documentation/resources/owl.css;
+    }
+    location = /lod/ontology/gadm-administrative-areas/resources/extra.css {
+        alias /usr/share/nginx/html/onto/admin-regions-gadm-documentation/resources/extra.css;
+    }
+    location = /lod/ontology/gadm-administrative-areas/resources/primer.css {
+        alias /usr/share/nginx/html/onto/admin-regions-gadm-documentation/resources/primer.css;
+    }
+    location = /lod/ontology/gadm-administrative-areas/resources/rec.css {
+        alias /usr/share/nginx/html/onto/admin-regions-gadm-documentation/resources/rec.css;
+    }
+    location = /lod/ontology/gadm-administrative-areas/figures/admin-regions-gadm-schema-diagram.png {
+        alias /usr/share/nginx/html/onto/admin-regions-gadm-documentation/figures/admin-regions-gadm-schema-diagram.png;
+    }
+    location = /lod/ontology/gadm-administrative-areas/index-en.html {
+        alias /usr/share/nginx/html/onto/admin-regions-gadm-documentation/index-en.html;
+    }
+
+    #
+    # air-quality-epa-documentation
+    #
+    location = /lod/ontology/epa-air-quality.ttl {
+        alias /usr/share/nginx/html/onto/air-quality-epa-documentation/ontology.ttl;
+    }
+    location = /lod/ontology/epa-air-quality.nt {
+        alias /usr/share/nginx/html/onto/air-quality-epa-documentation/ontology.nt;
+    }
+    location = /lod/ontology/epa-air-quality.jsonld {
+        alias /usr/share/nginx/html/onto/air-quality-epa-documentation/ontology.jsonld;
+    }
+    location = /lod/ontology/epa-air-quality.rdf {
+        alias /usr/share/nginx/html/onto/air-quality-epa-documentation/ontology.rdf;
+    }
+    location = /lod/ontology/epa-air-quality/ {
+        alias /usr/share/nginx/html/onto/air-quality-epa-documentation/;
+        index index-en.html;
+    }
+    location = /lod/ontology/epa-air-quality {
+        alias /usr/share/nginx/html/onto/air-quality-epa-documentation/;
+        index index-en.html;
+    }
+    location = /lod/ontology/epa-air-quality/resources/marked.min.js {
+        alias /usr/share/nginx/html/onto/air-quality-epa-documentation/resources/marked.min.js;
+    }
+    location = /lod/ontology/epa-air-quality/resources/jquery.js {
+        alias /usr/share/nginx/html/onto/air-quality-epa-documentation/resources/jquery.js;
+    }
+    location = /lod/ontology/epa-air-quality/resources/owl.css {
+        alias /usr/share/nginx/html/onto/air-quality-epa-documentation/resources/owl.css;
+    }
+    location = /lod/ontology/epa-air-quality/resources/extra.css {
+        alias /usr/share/nginx/html/onto/air-quality-epa-documentation/resources/extra.css;
+    }
+    location = /lod/ontology/epa-air-quality/resources/primer.css {
+        alias /usr/share/nginx/html/onto/air-quality-epa-documentation/resources/primer.css;
+    }
+    location = /lod/ontology/epa-air-quality/resources/rec.css {
+        alias /usr/share/nginx/html/onto/air-quality-epa-documentation/resources/rec.css;
+    }
+    location = /lod/ontology/epa-air-quality/figures/air-quality-epa-schema-diagram.png {
+        alias /usr/share/nginx/html/onto/air-quality-epa-documentation/figures/air-quality-epa-schema-diagram.png;
+    }
+    location = /lod/ontology/epa-air-quality/index-en.html {
+        alias /usr/share/nginx/html/onto/air-quality-epa-documentation/index-en.html;
+    }
+
+    #
+    # census-uscb-documentation
+    #
+    location = /lod/ontology/uscb-cbsa-census.ttl {
+        alias /usr/share/nginx/html/onto/census-uscb-documentation/ontology.ttl;
+    }
+    location = /lod/ontology/uscb-cbsa-census.nt {
+        alias /usr/share/nginx/html/onto/census-uscb-documentation/ontology.nt;
+    }
+    location = /lod/ontology/uscb-cbsa-census.jsonld {
+        alias /usr/share/nginx/html/onto/census-uscb-documentation/ontology.jsonld;
+    }
+    location = /lod/ontology/uscb-cbsa-census.rdf {
+        alias /usr/share/nginx/html/onto/census-uscb-documentation/ontology.rdf;
+    }
+    location = /lod/ontology/uscb-cbsa-census/ {
+        alias /usr/share/nginx/html/onto/census-uscb-documentation/;
+        index index-en.html;
+    }
+    location = /lod/ontology/uscb-cbsa-census {
+        alias /usr/share/nginx/html/onto/census-uscb-documentation/;
+        index index-en.html;
+    }
+    location = /lod/ontology/uscb-cbsa-census/resources/marked.min.js {
+        alias /usr/share/nginx/html/onto/census-uscb-documentation/resources/marked.min.js;
+    }
+    location = /lod/ontology/uscb-cbsa-census/resources/jquery.js {
+        alias /usr/share/nginx/html/onto/census-uscb-documentation/resources/jquery.js;
+    }
+    location = /lod/ontology/uscb-cbsa-census/resources/owl.css {
+        alias /usr/share/nginx/html/onto/census-uscb-documentation/resources/owl.css;
+    }
+    location = /lod/ontology/uscb-cbsa-census/resources/extra.css {
+        alias /usr/share/nginx/html/onto/census-uscb-documentation/resources/extra.css;
+    }
+    location = /lod/ontology/uscb-cbsa-census/resources/primer.css {
+        alias /usr/share/nginx/html/onto/census-uscb-documentation/resources/primer.css;
+    }
+    location = /lod/ontology/uscb-cbsa-census/resources/rec.css {
+        alias /usr/share/nginx/html/onto/census-uscb-documentation/resources/rec.css;
+    }
+    location = /lod/ontology/uscb-cbsa-census/figures/census-uscb-schema-diagram.png {
+        alias /usr/share/nginx/html/onto/census-uscb-documentation/figures/census-uscb-schema-diagram.png;
+    }
+    location = /lod/ontology/uscb-cbsa-census/index-en.html {
+        alias /usr/share/nginx/html/onto/census-uscb-documentation/index-en.html;
+    }
+
+    #
+    # climate-divisions-observations-noaa-documentation
+    #
+    location = /lod/ontology/noaa-climate-division-observation.ttl {
+        alias /usr/share/nginx/html/onto/climate-divisions-observations-noaa-documentation/ontology.ttl;
+    }
+    location = /lod/ontology/noaa-climate-division-observation.nt {
+        alias /usr/share/nginx/html/onto/climate-divisions-observations-noaa-documentation/ontology.nt;
+    }
+    location = /lod/ontology/noaa-climate-division-observation.jsonld {
+        alias /usr/share/nginx/html/onto/climate-divisions-observations-noaa-documentation/ontology.jsonld;
+    }
+    location = /lod/ontology/noaa-climate-division-observation.rdf {
+        alias /usr/share/nginx/html/onto/climate-divisions-observations-noaa-documentation/ontology.rdf;
+    }
+    location = /lod/ontology/noaa-climate-division-observation/ {
+        alias /usr/share/nginx/html/onto/climate-divisions-observations-noaa-documentation/;
+        index index-en.html;
+    }
+    location = /lod/ontology/noaa-climate-division-observation {
+        alias /usr/share/nginx/html/onto/climate-divisions-observations-noaa-documentation/;
+        index index-en.html;
+    }
+    location = /lod/ontology/noaa-climate-division-observation/resources/marked.min.js {
+        alias /usr/share/nginx/html/onto/climate-divisions-observations-noaa-documentation/resources/marked.min.js;
+    }
+    location = /lod/ontology/noaa-climate-division-observation/resources/jquery.js {
+        alias /usr/share/nginx/html/onto/climate-divisions-observations-noaa-documentation/resources/jquery.js;
+    }
+    location = /lod/ontology/noaa-climate-division-observation/resources/owl.css {
+        alias /usr/share/nginx/html/onto/climate-divisions-observations-noaa-documentation/resources/owl.css;
+    }
+    location = /lod/ontology/noaa-climate-division-observation/resources/extra.css {
+        alias /usr/share/nginx/html/onto/climate-divisions-observations-noaa-documentation/resources/extra.css;
+    }
+    location = /lod/ontology/noaa-climate-division-observation/resources/primer.css {
+        alias /usr/share/nginx/html/onto/climate-divisions-observations-noaa-documentation/resources/primer.css;
+    }
+    location = /lod/ontology/noaa-climate-division-observation/resources/rec.css {
+        alias /usr/share/nginx/html/onto/climate-divisions-observations-noaa-documentation/resources/rec.css;
+    }
+    location = /lod/ontology/noaa-climate-division-observation/figures/climate-divisions-observations-noaa-schema-diagram.png {
+        alias /usr/share/nginx/html/onto/climate-divisions-observations-noaa-documentation/figures/climate-divisions-observations-noaa-schema-diagram.png;
+    }
+    location = /lod/ontology/noaa-climate-division-observation/index-en.html {
+        alias /usr/share/nginx/html/onto/climate-divisions-observations-noaa-documentation/index-en.html;
+    }
+
+    #
+    # cropland-types-usda-documentation
+    #
+    location = /lod/ontology/usda-cropland.ttl {
+        alias /usr/share/nginx/html/onto/cropland-types-usda-documentation/ontology.ttl;
+    }
+    location = /lod/ontology/usda-cropland.nt {
+        alias /usr/share/nginx/html/onto/cropland-types-usda-documentation/ontology.nt;
+    }
+    location = /lod/ontology/usda-cropland.jsonld {
+        alias /usr/share/nginx/html/onto/cropland-types-usda-documentation/ontology.jsonld;
+    }
+    location = /lod/ontology/usda-cropland.rdf {
+        alias /usr/share/nginx/html/onto/cropland-types-usda-documentation/ontology.rdf;
+    }
+    location = /lod/ontology/usda-cropland/ {
+        alias /usr/share/nginx/html/onto/cropland-types-usda-documentation/;
+        index index-en.html;
+    }
+    location = /lod/ontology/usda-cropland {
+        alias /usr/share/nginx/html/onto/cropland-types-usda-documentation/;
+        index index-en.html;
+    }
+    location = /lod/ontology/usda-cropland/resources/marked.min.js {
+        alias /usr/share/nginx/html/onto/cropland-types-usda-documentation/resources/marked.min.js;
+    }
+    location = /lod/ontology/usda-cropland/resources/jquery.js {
+        alias /usr/share/nginx/html/onto/cropland-types-usda-documentation/resources/jquery.js;
+    }
+    location = /lod/ontology/usda-cropland/resources/owl.css {
+        alias /usr/share/nginx/html/onto/cropland-types-usda-documentation/resources/owl.css;
+    }
+    location = /lod/ontology/usda-cropland/resources/extra.css {
+        alias /usr/share/nginx/html/onto/cropland-types-usda-documentation/resources/extra.css;
+    }
+    location = /lod/ontology/usda-cropland/resources/primer.css {
+        alias /usr/share/nginx/html/onto/cropland-types-usda-documentation/resources/primer.css;
+    }
+    location = /lod/ontology/usda-cropland/resources/rec.css {
+        alias /usr/share/nginx/html/onto/cropland-types-usda-documentation/resources/rec.css;
+    }
+    location = /lod/ontology/usda-cropland/figures/cropland-types-usda-schema-diagram.png {
+        alias /usr/share/nginx/html/onto/cropland-types-usda-documentation/figures/cropland-types-usda-schema-diagram.png;
+    }
+    location = /lod/ontology/usda-cropland/index-en.html {
+        alias /usr/share/nginx/html/onto/cropland-types-usda-documentation/index-en.html;
+    }
+
+    #
+    # earthquake-usgs-documentation
+    #
+    location = /lod/ontology/usgs-earthquake.ttl {
+        alias /usr/share/nginx/html/onto/earthquake-usgs-documentation/ontology.ttl;
+    }
+    location = /lod/ontology/usgs-earthquake.nt {
+        alias /usr/share/nginx/html/onto/earthquake-usgs-documentation/ontology.nt;
+    }
+    location = /lod/ontology/usgs-earthquake.jsonld {
+        alias /usr/share/nginx/html/onto/earthquake-usgs-documentation/ontology.jsonld;
+    }
+    location = /lod/ontology/usgs-earthquake.rdf {
+        alias /usr/share/nginx/html/onto/earthquake-usgs-documentation/ontology.rdf;
+    }
+    location = /lod/ontology/usgs-earthquake/ {
+        alias /usr/share/nginx/html/onto/earthquake-usgs-documentation/;
+        index index-en.html;
+    }
+    location = /lod/ontology/usgs-earthquake {
+        alias /usr/share/nginx/html/onto/earthquake-usgs-documentation/;
+        index index-en.html;
+    }
+    location = /lod/ontology/usgs-earthquake/resources/marked.min.js {
+        alias /usr/share/nginx/html/onto/earthquake-usgs-documentation/resources/marked.min.js;
+    }
+    location = /lod/ontology/usgs-earthquake/resources/jquery.js {
+        alias /usr/share/nginx/html/onto/earthquake-usgs-documentation/resources/jquery.js;
+    }
+    location = /lod/ontology/usgs-earthquake/resources/owl.css {
+        alias /usr/share/nginx/html/onto/earthquake-usgs-documentation/resources/owl.css;
+    }
+    location = /lod/ontology/usgs-earthquake/resources/extra.css {
+        alias /usr/share/nginx/html/onto/earthquake-usgs-documentation/resources/extra.css;
+    }
+    location = /lod/ontology/usgs-earthquake/resources/primer.css {
+        alias /usr/share/nginx/html/onto/earthquake-usgs-documentation/resources/primer.css;
+    }
+    location = /lod/ontology/usgs-earthquake/resources/rec.css {
+        alias /usr/share/nginx/html/onto/earthquake-usgs-documentation/resources/rec.css;
+    }
+    location = /lod/ontology/usgs-earthquake/figures/cropland-types-usda-schema-diagram.png {
+        alias /usr/share/nginx/html/onto/earthquake-usgs-documentation/figures/cropland-types-usda-schema-diagram.png;
+    }
+    location = /lod/ontology/usgs-earthquake/index-en.html {
+        alias /usr/share/nginx/html/onto/earthquake-usgs-documentation/index-en.html;
+    }
+
+    #
+    # federal-judicial-district-doj-documentation
+    #
+    location = /lod/ontology/doj-federal-judicial-districts.ttl {
+        alias /usr/share/nginx/html/onto/federal-judicial-district-doj-documentation/ontology.ttl;
+    }
+    location = /lod/ontology/doj-federal-judicial-districts.nt {
+        alias /usr/share/nginx/html/onto/federal-judicial-district-doj-documentation/ontology.nt;
+    }
+    location = /lod/ontology/doj-federal-judicial-districts.jsonld {
+        alias /usr/share/nginx/html/onto/federal-judicial-district-doj-documentation/ontology.jsonld;
+    }
+    location = /lod/ontology/doj-federal-judicial-districts.rdf {
+        alias /usr/share/nginx/html/onto/federal-judicial-district-doj-documentation/ontology.rdf;
+    }
+    location = /lod/ontology/doj-federal-judicial-districts/ {
+        alias /usr/share/nginx/html/onto/federal-judicial-district-doj-documentation/;
+        index index-en.html;
+    }
+    location = /lod/ontology/doj-federal-judicial-districts {
+        alias /usr/share/nginx/html/onto/federal-judicial-district-doj-documentation/;
+        index index-en.html;
+    }
+    location = /lod/ontology/doj-federal-judicial-districts/resources/marked.min.js {
+        alias /usr/share/nginx/html/onto/federal-judicial-district-doj-documentation/resources/marked.min.js;
+    }
+    location = /lod/ontology/doj-federal-judicial-districts/resources/jquery.js {
+        alias /usr/share/nginx/html/onto/federal-judicial-district-doj-documentation/resources/jquery.js;
+    }
+    location = /lod/ontology/doj-federal-judicial-districts/resources/owl.css {
+        alias /usr/share/nginx/html/onto/federal-judicial-district-doj-documentation/resources/owl.css;
+    }
+    location = /lod/ontology/doj-federal-judicial-districts/resources/extra.css {
+        alias /usr/share/nginx/html/onto/federal-judicial-district-doj-documentation/resources/extra.css;
+    }
+    location = /lod/ontology/doj-federal-judicial-districts/resources/primer.css {
+        alias /usr/share/nginx/html/onto/federal-judicial-district-doj-documentation/resources/primer.css;
+    }
+    location = /lod/ontology/doj-federal-judicial-districts/resources/rec.css {
+        alias /usr/share/nginx/html/onto/federal-judicial-district-doj-documentation/resources/rec.css;
+    }
+    location = /lod/ontology/doj-federal-judicial-districts/figures/cropland-types-usda-schema-diagram.png {
+        alias /usr/share/nginx/html/onto/federal-judicial-district-doj-documentation/figures/cropland-types-usda-schema-diagram.png;
+    }
+    location = /lod/ontology/doj-federal-judicial-districts/index-en.html {
+        alias /usr/share/nginx/html/onto/federal-judicial-district-doj-documentation/index-en.html;
+    }
+
+    #
+    # historical-fires-mtbs-documentation
+    #
+    location = /lod/ontology/mtbs-wildfire.ttl {
+        alias /usr/share/nginx/html/onto/historical-fires-mtbs-documentation/ontology.ttl;
+    }
+    location = /lod/ontology/mtbs-wildfire.nt {
+        alias /usr/share/nginx/html/onto/historical-fires-mtbs-documentation/ontology.nt;
+    }
+    location = /lod/ontology/mtbs-wildfire.jsonld {
+        alias /usr/share/nginx/html/onto/historical-fires-mtbs-documentation/ontology.jsonld;
+    }
+    location = /lod/ontology/mtbs-wildfire.rdf {
+        alias /usr/share/nginx/html/onto/historical-fires-mtbs-documentation/ontology.rdf;
+    }
+    location = /lod/ontology/mtbs-wildfire/ {
+        alias /usr/share/nginx/html/onto/historical-fires-mtbs-documentation/;
+        index index-en.html;
+    }
+    location = /lod/ontology/mtbs-wildfire {
+        alias /usr/share/nginx/html/onto/historical-fires-mtbs-documentation/;
+        index index-en.html;
+    }
+    location = /lod/ontology/mtbs-wildfire/resources/marked.min.js {
+        alias /usr/share/nginx/html/onto/historical-fires-mtbs-documentation/resources/marked.min.js;
+    }
+    location = /lod/ontology/mtbs-wildfire/resources/jquery.js {
+        alias /usr/share/nginx/html/onto/historical-fires-mtbs-documentation/resources/jquery.js;
+    }
+    location = /lod/ontology/mtbs-wildfire/resources/owl.css {
+        alias /usr/share/nginx/html/onto/historical-fires-mtbs-documentation/resources/owl.css;
+    }
+    location = /lod/ontology/mtbs-wildfire/resources/extra.css {
+        alias /usr/share/nginx/html/onto/historical-fires-mtbs-documentation/resources/extra.css;
+    }
+    location = /lod/ontology/mtbs-wildfire/resources/primer.css {
+        alias /usr/share/nginx/html/onto/historical-fires-mtbs-documentation/resources/primer.css;
+    }
+    location = /lod/ontology/mtbs-wildfire/resources/rec.css {
+        alias /usr/share/nginx/html/onto/historical-fires-mtbs-documentation/resources/rec.css;
+    }
+    location = /lod/ontology/mtbs-wildfire/figures/historical-fires-mtbs-schema-diagram.png {
+        alias /usr/share/nginx/html/onto/historical-fires-mtbs-documentation/figures/historical-fires-mtbs-schema-diagram.png;
+    }
+    location = /lod/ontology/mtbs-wildfire/index-en.html {
+        alias /usr/share/nginx/html/onto/historical-fires-mtbs-documentation/index-en.html;
+    }
+
+    #
+    # hurricane-tracks-noaa-documentation
+    #
+    location = /lod/ontology/noaa-hurricane-tracks.ttl {
+        alias /usr/share/nginx/html/onto/hurricane-tracks-noaa-documentation/ontology.ttl;
+    }
+    location = /lod/ontology/noaa-hurricane-tracks.nt {
+        alias /usr/share/nginx/html/onto/hurricane-tracks-noaa-documentation/ontology.nt;
+    }
+    location = /lod/ontology/noaa-hurricane-tracks.jsonld {
+        alias /usr/share/nginx/html/onto/hurricane-tracks-noaa-documentation/ontology.jsonld;
+    }
+    location = /lod/ontology/noaa-hurricane-tracks.rdf {
+        alias /usr/share/nginx/html/onto/hurricane-tracks-noaa-documentation/ontology.rdf;
+    }
+    location = /lod/ontology/noaa-hurricane-tracks/ {
+        alias /usr/share/nginx/html/onto/hurricane-tracks-noaa-documentation/;
+        index index-en.html;
+    }
+    location = /lod/ontology/noaa-hurricane-tracks {
+        alias /usr/share/nginx/html/onto/hurricane-tracks-noaa-documentation/;
+        index index-en.html;
+    }
+    location = /lod/ontology/noaa-hurricane-tracks/resources/marked.min.js {
+        alias /usr/share/nginx/html/onto/hurricane-tracks-noaa-documentation/resources/marked.min.js;
+    }
+    location = /lod/ontology/noaa-hurricane-tracks/resources/jquery.js {
+        alias /usr/share/nginx/html/onto/hurricane-tracks-noaa-documentation/resources/jquery.js;
+    }
+    location = /lod/ontology/noaa-hurricane-tracks/resources/owl.css {
+        alias /usr/share/nginx/html/onto/hurricane-tracks-noaa-documentation/resources/owl.css;
+    }
+    location = /lod/ontology/noaa-hurricane-tracks/resources/extra.css {
+        alias /usr/share/nginx/html/onto/hurricane-tracks-noaa-documentation/resources/extra.css;
+    }
+    location = /lod/ontology/noaa-hurricane-tracks/resources/primer.css {
+        alias /usr/share/nginx/html/onto/hurricane-tracks-noaa-documentation/resources/primer.css;
+    }
+    location = /lod/ontology/noaa-hurricane-tracks/resources/rec.css {
+        alias /usr/share/nginx/html/onto/hurricane-tracks-noaa-documentation/resources/rec.css;
+    }
+    location = /lod/ontology/noaa-hurricane-tracks/figures/hurricane-tracks-noaa-schema-diagram.png {
+        alias /usr/share/nginx/html/onto/hurricane-tracks-noaa-documentation/figures/hurricane-tracks-noaa-schema-diagram.png;
+    }
+    location = /lod/ontology/noaa-hurricane-tracks/index-en.html {
+        alias /usr/share/nginx/html/onto/hurricane-tracks-noaa-documentation/index-en.html;
+    }
+
+    #
+    # national-weather-zone-noaa-documentation
+    #
+    location = /lod/ontology/noaa-national-weather-zone.ttl {
+        alias /usr/share/nginx/html/onto/national-weather-zone-noaa-documentation/ontology.ttl;
+    }
+    location = /lod/ontology/noaa-national-weather-zone.nt {
+        alias /usr/share/nginx/html/onto/national-weather-zone-noaa-documentation/ontology.nt;
+    }
+    location = /lod/ontology/noaa-national-weather-zone.jsonld {
+        alias /usr/share/nginx/html/onto/national-weather-zone-noaa-documentation/ontology.jsonld;
+    }
+    location = /lod/ontology/noaa-national-weather-zone.rdf {
+        alias /usr/share/nginx/html/onto/national-weather-zone-noaa-documentation/ontology.rdf;
+    }
+    location = /lod/ontology/noaa-national-weather-zone/ {
+        alias /usr/share/nginx/html/onto/national-weather-zone-noaa-documentation/;
+        index index-en.html;
+    }
+    location = /lod/ontology/noaa-national-weather-zone {
+        alias /usr/share/nginx/html/onto/national-weather-zone-noaa-documentation/;
+        index index-en.html;
+    }
+    location = /lod/ontology/noaa-national-weather-zone/resources/marked.min.js {
+        alias /usr/share/nginx/html/onto/national-weather-zone-noaa-documentation/resources/marked.min.js;
+    }
+    location = /lod/ontology/noaa-national-weather-zone/resources/jquery.js {
+        alias /usr/share/nginx/html/onto/national-weather-zone-noaa-documentation/resources/jquery.js;
+    }
+    location = /lod/ontology/noaa-national-weather-zone/resources/owl.css {
+        alias /usr/share/nginx/html/onto/national-weather-zone-noaa-documentation/resources/owl.css;
+    }
+    location = /lod/ontology/noaa-national-weather-zone/resources/extra.css {
+        alias /usr/share/nginx/html/onto/national-weather-zone-noaa-documentation/resources/extra.css;
+    }
+    location = /lod/ontology/noaa-national-weather-zone/resources/primer.css {
+        alias /usr/share/nginx/html/onto/national-weather-zone-noaa-documentation/resources/primer.css;
+    }
+    location = /lod/ontology/noaa-national-weather-zone/resources/rec.css {
+        alias /usr/share/nginx/html/onto/national-weather-zone-noaa-documentation/resources/rec.css;
+    }
+    location = /lod/ontology/noaa-national-weather-zone/figures/national-weather-zone-schema-diagram.png {
+        alias /usr/share/nginx/html/onto/national-weather-zone-noaa-documentation/figures/national-weather-zone-schema-diagram.png;
+    }
+    location = /lod/ontology/noaa-national-weather-zone/index-en.html {
+        alias /usr/share/nginx/html/onto/national-weather-zone-noaa-documentation/index-en.html;
+    }
+
+    #
+    # wildfire-nifc-documentation
+    #
+    location = /lod/ontology/nifc-wildfire.ttl {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/ontology.ttl;
+    }
+    location = /lod/ontology/nifc-wildfire.nt {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/ontology.nt;
+    }
+    location = /lod/ontology/nifc-wildfire.jsonld {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/ontology.jsonld;
+    }
+    location = /lod/ontology/nifc-wildfire.rdf {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/ontology.rdf;
+    }
+    location = /lod/ontology/nifc-wildfire/ {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/;
+        index index-en.html;
+    }
+    location = /lod/ontology/nifc-wildfire {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/;
+        index index-en.html;
+    }
+    location = /lod/ontology/nifc-wildfire/resources/marked.min.js {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/resources/marked.min.js;
+    }
+    location = /lod/ontology/nifc-wildfire/resources/jquery.js {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/resources/jquery.js;
+    }
+    location = /lod/ontology/nifc-wildfire/resources/owl.css {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/resources/owl.css;
+    }
+    location = /lod/ontology/nifc-wildfire/resources/extra.css {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/resources/extra.css;
+    }
+    location = /lod/ontology/nifc-wildfire/resources/primer.css {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/resources/primer.css;
+    }
+    location = /lod/ontology/nifc-wildfire/resources/rec.css {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/resources/rec.css;
+    }
+    location = /lod/ontology/nifc-wildfire/figures/national-weather-zone-schema-diagram.png {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/figures/national-weather-zone-schema-diagram.png;
+    }
+    location = /lod/ontology/nifc-wildfire/index-en.html {
+        alias /usr/share/nginx/html/onto/wildfire-nifc-documentation/index-en.html;
+    }
 
     # Server root directs to the faceted search
     location /  {
@@ -108,11 +635,7 @@ server {
 
     #Static KW Panels Application
     location /kw-panels/ {
-
         alias /usr/share/nginx/html/kw-panels/ ;
-        ### optional: proxy instead of alias
-        # proxy_pass http://127.0.0.1:3002/;
-
         index index.html;
     }
 
@@ -133,6 +656,7 @@ server {
     
     # VOID Descriptor
     location /.well-known/void {
-        alias /usr/share/nginx/html/void/void.ttl;
+        alias /usr/share/nginx/html/onto/void.ttl;
     }
+
 }


### PR DESCRIPTION
Relates to #35 and #32 #4
This version matches the suggested version in the GraphDB docs https://graphdb.ontotext.com/documentation/10.7/elasticsearch-graphdb-connector.html