### PR TITLE
Redirect workbench to graphdb

### DIFF
--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -674,12 +674,12 @@ server {
 
     # Workbench redirect
     location /workbench{
-	return 301 /graphdb;
+	return 301 /graphdb/sparql;
     }
 
   # Workbench redirect
     location /workbench/{
-        return 301 /graphdb;
+        return 301 /graphdb/sparql;
     }
 
     # Robots.txt

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -672,6 +672,16 @@ server {
     }
 
 
+    # Workbench redirect
+    location /workbench{
+	return 301 /graphdb;
+    }
+
+  # Workbench redirect
+    location /workbench/{
+        return 301 /graphdb;
+    }
+
     # Robots.txt
     location /robots.txt {
         alias /usr/share/nginx/html/robots.txt;


### PR DESCRIPTION
This PR redirects requests from the (previously) custom workbench to the standard GraphDB instance. Fixes #44 

To test: visit stko-kwg.geog.ucsb.edu/workbench